### PR TITLE
Fix typo in Gold16 driver build script

### DIFF
--- a/SoundDrivers/MG16.BAT
+++ b/SoundDrivers/MG16.BAT
@@ -1,5 +1,5 @@
 tasm /m /ut310 gold16
 tlink /3 gold16
-execom m16 itgold16.drv
+execom gold16 itgold16.drv
 copy itgold16.drv ..
 


### PR DESCRIPTION
The call to `execom` incorrectly specifies `m16.exe` instead of `gold16.exe`. This PR fixes that.